### PR TITLE
Improve erroring across the codebase

### DIFF
--- a/src/Core/Adjust/Adjust.hs
+++ b/src/Core/Adjust/Adjust.hs
@@ -85,28 +85,23 @@ import Core.WHNF
 -- book adjustment where recursive references aren't available yet.
 -- When called from adjustBook, enums have already been resolved at the book level.
 -- When called standalone (e.g., from parseTerm), enums are resolved here.
-adjust :: Book -> Term -> Term
-adjust book term =
-  -- trace ("done: " ++ show done) $
-  done
-  where
-    -- First resolve enums to their FQNs (needed for standalone use)
-    resolved = case resolveEnumsInTerm (extractEnums book) term of
-      Done t -> t
-      Fail e -> error $ show e
-    flat = flattenPats 0 noSpan book resolved
-    npat = desugarPats 0 noSpan flat
-    nfrk = desugarFrks book 0 npat
-    etas = reduceEtas 0 nfrk
-    done = bind etas
+adjust :: Book -> Term -> Result Term
+adjust book term = do
+  -- First resolve enums to their FQNs (needed for standalone use)
+  resolved <- resolveEnumsInTerm (extractEnums book) term
+  let flat = flattenPats 0 noSpan book resolved
+  npat <- desugarPats 0 noSpan flat
+  let nfrk = desugarFrks book 0 npat
+  let etas = reduceEtas 0 nfrk
+  Done $ bind etas
 
 
 -- | Adjusts a term. simplifying patterns but leaving terms as Pats.
-adjustWithPats :: Book -> Term -> Term
-adjustWithPats book term =
-  ret
-  where
-    ret = bind (desugarFrks book 0 (flattenPats 0 noSpan book term))
+adjustWithPats :: Book -> Term -> Result Term
+adjustWithPats book term = do
+  let flat = flattenPats 0 noSpan book term
+  let frks = desugarFrks book 0 flat
+  Done $ bind frks
 
 -- The state for the adjustment process. It holds:
 -- 1. The book of already-adjusted definitions.
@@ -119,24 +114,26 @@ type AdjustState = (Book, S.Set Name)
 -- all definitions it depends on have already been adjusted.
 -- This is crucial for functions like `flatten` which may look up references.
 -- After adjusting all definitions, it checks for free variables.
-adjustBook :: Book -> Book
-adjustBook book@(Book defs names) =
+adjustBook :: Book -> Result Book
+adjustBook book@(Book defs names) = do
   -- First resolve all enums in the entire book
-  let resolvedBook = case resolveEnumsInBook book of
-        Done b -> b
-        Fail e -> error $ show e
-      adjustedBook = fst $ execState (mapM_ (adjustDef resolvedBook S.empty adjust) (M.keys defs)) (Book M.empty names, S.empty)
-  in adjustedBook -- checkFreeVarsInBook disabled: not in main branch
+  resolvedBook <- resolveEnumsInBook book
+  let adjustFn b t = case adjust b t of
+        Done t' -> t'
+        Fail e  -> error $ show e  -- Convert to error for now
+  let adjustedBook = fst $ execState (mapM_ (adjustDef resolvedBook S.empty adjustFn) (M.keys defs)) (Book M.empty names, S.empty)
+  Done adjustedBook -- checkFreeVarsInBook disabled: not in main branch
 
 -- | Adjusts the entire book, simplifying patterns but without removing Pat terms.
-adjustBookWithPats :: Book -> Book
-adjustBookWithPats book@(Book defs names) =
+adjustBookWithPats :: Book -> Result Book
+adjustBookWithPats book@(Book defs names) = do
   -- First resolve all enums in the entire book
-  let resolvedBook = case resolveEnumsInBook book of
-        Done b -> b
-        Fail e -> error $ show e
-      adjustedBook = fst $ execState (mapM_ (adjustDef resolvedBook S.empty adjustWithPats) (M.keys defs)) (Book M.empty names, S.empty)
-  in adjustedBook -- checkFreeVarsInBook disabled: not in main branch
+  resolvedBook <- resolveEnumsInBook book
+  let adjustFn b t = case adjustWithPats b t of
+        Done t' -> t'
+        Fail e  -> error $ show e  -- Convert to error for now
+  let adjustedBook = fst $ execState (mapM_ (adjustDef resolvedBook S.empty adjustFn) (M.keys defs)) (Book M.empty names, S.empty)
+  Done adjustedBook -- checkFreeVarsInBook disabled: not in main branch
 
 -- | Checks all definitions in a book for free variables.
 -- This should be called after all adjustments are complete.

--- a/src/Core/Adjust/DesugarPats.hs
+++ b/src/Core/Adjust/DesugarPats.hs
@@ -13,162 +13,269 @@ import Core.WHNF
 import qualified Data.Set as S
 import Debug.Trace (trace)
 
-desugarPats :: Int -> Span -> Term -> Term
-desugarPats d span (Var n i)       = Var n i
-desugarPats d span (Ref n i)       = Ref n i
-desugarPats d span (Sub t)         = Sub (desugarPats d span t)
-desugarPats d span (Fix n f)       = Fix n (\x -> desugarPats (d+1) span (f x))
-desugarPats d span (Let k t v f)   = Let k (fmap (desugarPats d span) t) (desugarPats d span v) (\x -> desugarPats (d+1) span (f x))
-desugarPats d span (Use k v f)     = Use k (desugarPats d span v) (\x -> desugarPats (d+1) span (f x))
-desugarPats d span Set             = Set
-desugarPats d span (Chk x t)       = Chk (desugarPats d span x) (desugarPats d span t)
-desugarPats d span (Tst x)         = Tst (desugarPats d span x)
-desugarPats d span Emp             = Emp
-desugarPats d span EmpM            = EmpM
-desugarPats d span Uni             = Uni
-desugarPats d span One             = One
-desugarPats d span (UniM f)        = UniM (desugarPats d span f)
-desugarPats d span Bit             = Bit
-desugarPats d span Bt0             = Bt0
-desugarPats d span Bt1             = Bt1
-desugarPats d span (BitM f t)      = BitM (desugarPats d span f) (desugarPats d span t)
-desugarPats d span Nat             = Nat
-desugarPats d span Zer             = Zer
-desugarPats d span (Suc n)         = Suc (desugarPats d span n)
-desugarPats d span (NatM z s)      = NatM (desugarPats d span z) (desugarPats d span s)
-desugarPats d span (Lst t)         = Lst (desugarPats d span t)
-desugarPats d span Nil             = Nil
-desugarPats d span (Con h t)       = Con (desugarPats d span h) (desugarPats d span t)
-desugarPats d span (LstM n c)      = LstM (desugarPats d span n) (desugarPats d span c)
-desugarPats d span (Enu s)         = Enu s
-desugarPats d span (Sym s)         = Sym s
-desugarPats d span (EnuM c e)      = EnuM [(s, desugarPats d span t) | (s, t) <- c] (desugarPats d span e)
-desugarPats d span (Sig a b)       = Sig (desugarPats d span a) (desugarPats d span b)
-desugarPats d span (Tup a b)       = Tup (desugarPats d span a) (desugarPats d span b)
-desugarPats d span (SigM f)        = SigM (desugarPats d span f)
-desugarPats d span (All a b)       = All (desugarPats d span a) (desugarPats d span b)
-desugarPats d span (Lam n t f)     = Lam n (fmap (desugarPats d span) t) (\x -> desugarPats (d+1) span (f x))
-desugarPats d span (App f x)       = App (desugarPats d span f) (desugarPats d span x)
-desugarPats d span (Eql t a b)     = Eql (desugarPats d span t) (desugarPats d span a) (desugarPats d span b)
-desugarPats d span Rfl             = Rfl
-desugarPats d span (EqlM f)        = EqlM (desugarPats d span f)
-desugarPats d span (Met i t x)     = Met i (desugarPats d span t) (map (desugarPats d span) x)
-desugarPats d span Era             = Era
-desugarPats d span (Sup l a b)     = Sup (desugarPats d span l) (desugarPats d span a) (desugarPats d span b)
-desugarPats d span (SupM l f)      = SupM (desugarPats d span l) (desugarPats d span f)
-desugarPats d span (Frk l a b)     = Frk (desugarPats d span l) (desugarPats d span a) (desugarPats d span b)
-desugarPats d span (Rwt e f)       = Rwt (desugarPats d span e) (desugarPats d span f)
-desugarPats d span (Num t)         = Num t
-desugarPats d span (Val v)         = Val v
-desugarPats d span (Op2 o a b)     = Op2 o (desugarPats d span a) (desugarPats d span b)
-desugarPats d span (Op1 o a)       = Op1 o (desugarPats d span a)
-desugarPats d span (Pri p)         = Pri p
-desugarPats d span (Log s x)       = Log (desugarPats d span s) (desugarPats d span x)
-desugarPats d span (Loc s t)       = Loc s (desugarPats d s t)
+desugarPats :: Int -> Span -> Term -> Result Term
+desugarPats d span (Var n i)       = Done $ Var n i
+desugarPats d span (Ref n i)       = Done $ Ref n i
+desugarPats d span (Sub t)         = do
+  t' <- desugarPats d span t
+  Done $ Sub t'
+desugarPats d span (Fix n f)       = Done $ Fix n (\x -> case desugarPats (d+1) span (f x) of Done t -> t; Fail e -> error $ show e)
+desugarPats d span (Let k t v f)   = do
+  t' <- mapM (desugarPats d span) t
+  v' <- desugarPats d span v
+  Done $ Let k t' v' (\x -> case desugarPats (d+1) span (f x) of Done t -> t; Fail e -> error $ show e)
+desugarPats d span (Use k v f)     = do
+  v' <- desugarPats d span v
+  Done $ Use k v' (\x -> case desugarPats (d+1) span (f x) of Done t -> t; Fail e -> error $ show e)
+desugarPats d span Set             = Done Set
+desugarPats d span (Chk x t)       = do
+  x' <- desugarPats d span x
+  t' <- desugarPats d span t
+  Done $ Chk x' t'
+desugarPats d span (Tst x)         = do
+  x' <- desugarPats d span x
+  Done $ Tst x'
+desugarPats d span Emp             = Done Emp
+desugarPats d span EmpM            = Done EmpM
+desugarPats d span Uni             = Done Uni
+desugarPats d span One             = Done One
+desugarPats d span (UniM f)        = do
+  f' <- desugarPats d span f
+  Done $ UniM f'
+desugarPats d span Bit             = Done Bit
+desugarPats d span Bt0             = Done Bt0
+desugarPats d span Bt1             = Done Bt1
+desugarPats d span (BitM f t)      = do
+  f' <- desugarPats d span f
+  t' <- desugarPats d span t
+  Done $ BitM f' t'
+desugarPats d span Nat             = Done Nat
+desugarPats d span Zer             = Done Zer
+desugarPats d span (Suc n)         = do
+  n' <- desugarPats d span n
+  Done $ Suc n'
+desugarPats d span (NatM z s)      = do
+  z' <- desugarPats d span z
+  s' <- desugarPats d span s
+  Done $ NatM z' s'
+desugarPats d span (Lst t)         = do
+  t' <- desugarPats d span t
+  Done $ Lst t'
+desugarPats d span Nil             = Done Nil
+desugarPats d span (Con h t)       = do
+  h' <- desugarPats d span h
+  t' <- desugarPats d span t
+  Done $ Con h' t'
+desugarPats d span (LstM n c)      = do
+  n' <- desugarPats d span n
+  c' <- desugarPats d span c
+  Done $ LstM n' c'
+desugarPats d span (Enu s)         = Done $ Enu s
+desugarPats d span (Sym s)         = Done $ Sym s
+desugarPats d span (EnuM c e)      = do
+  c' <- mapM (\(s, t) -> do t' <- desugarPats d span t; Done (s, t')) c
+  e' <- desugarPats d span e
+  Done $ EnuM c' e'
+desugarPats d span (Sig a b)       = do
+  a' <- desugarPats d span a
+  b' <- desugarPats d span b
+  Done $ Sig a' b'
+desugarPats d span (Tup a b)       = do
+  a' <- desugarPats d span a
+  b' <- desugarPats d span b
+  Done $ Tup a' b'
+desugarPats d span (SigM f)        = do
+  f' <- desugarPats d span f
+  Done $ SigM f'
+desugarPats d span (All a b)       = do
+  a' <- desugarPats d span a
+  b' <- desugarPats d span b
+  Done $ All a' b'
+desugarPats d span (Lam n t f)     = do
+  t' <- mapM (desugarPats d span) t
+  Done $ Lam n t' (\x -> case desugarPats (d+1) span (f x) of Done t -> t; Fail e -> error $ show e)
+desugarPats d span (App f x)       = do
+  f' <- desugarPats d span f
+  x' <- desugarPats d span x
+  Done $ App f' x'
+desugarPats d span (Eql t a b)     = do
+  t' <- desugarPats d span t
+  a' <- desugarPats d span a
+  b' <- desugarPats d span b
+  Done $ Eql t' a' b'
+desugarPats d span Rfl             = Done Rfl
+desugarPats d span (EqlM f)        = do
+  f' <- desugarPats d span f
+  Done $ EqlM f'
+desugarPats d span (Met i t x)     = do
+  t' <- desugarPats d span t
+  x' <- mapM (desugarPats d span) x
+  Done $ Met i t' x'
+desugarPats d span Era             = Done Era
+desugarPats d span (Sup l a b)     = do
+  l' <- desugarPats d span l
+  a' <- desugarPats d span a
+  b' <- desugarPats d span b
+  Done $ Sup l' a' b'
+desugarPats d span (SupM l f)      = do
+  l' <- desugarPats d span l
+  f' <- desugarPats d span f
+  Done $ SupM l' f'
+desugarPats d span (Frk l a b)     = do
+  l' <- desugarPats d span l
+  a' <- desugarPats d span a
+  b' <- desugarPats d span b
+  Done $ Frk l' a' b'
+desugarPats d span (Rwt e f)       = do
+  e' <- desugarPats d span e
+  f' <- desugarPats d span f
+  Done $ Rwt e' f'
+desugarPats d span (Num t)         = Done $ Num t
+desugarPats d span (Val v)         = Done $ Val v
+desugarPats d span (Op2 o a b)     = do
+  a' <- desugarPats d span a
+  b' <- desugarPats d span b
+  Done $ Op2 o a' b'
+desugarPats d span (Op1 o a)       = do
+  a' <- desugarPats d span a
+  Done $ Op1 o a'
+desugarPats d span (Pri p)         = Done $ Pri p
+desugarPats d span (Log s x)       = do
+  s' <- desugarPats d span s
+  x' <- desugarPats d span x
+  Done $ Log s' x'
+desugarPats d span (Loc s t)       = do
+  t' <- desugarPats d s t
+  Done $ Loc s t'
 desugarPats d span (Pat [s] ms cs) = match d span s ms cs
-desugarPats d span (Pat ss  ms []) = One
-desugarPats d span (Pat ss  ms cs) = errorWithSpan span "Invalid pattern: multiple scrutinees after flattening"
+desugarPats d span (Pat ss  ms []) = Done One
+desugarPats d span (Pat ss  ms cs) = Fail $ Unsupported span (Ctx []) (Just "Invalid pattern: multiple scrutinees after flattening")
 
-match :: Int -> Span -> Term -> [Move] -> [Case] -> Term
+match :: Int -> Span -> Term -> [Move] -> [Case] -> Result Term
 
 -- match x { 0n: z ; 1n+p: s }
 -- ---------------------------
 -- ~x { 0n: z ; 1n+: λp. s }
-match d span x ms (([(cut -> Zer)], z) : ([(cut -> Suc p)], s) : _) =
-  apps d (map snd ms) $ App (NatM if_zer if_suc) x
-  where if_zer = lam d (map fst ms) $ desugarPats d span z
-        if_suc = Lam (patOf d p) (Just Nat) $ \x -> lam d (map fst ms) $ desugarPats (d+1) span s
+match d span x ms (([(cut -> Zer)], z) : ([(cut -> Suc p)], s) : _) = do
+  z' <- desugarPats d span z
+  s' <- desugarPats (d+1) span s
+  let if_zer = lam d (map fst ms) z'
+  let if_suc = Lam (patOf d p) (Just Nat) $ \x -> lam d (map fst ms) s'
+  Done $ apps d (map snd ms) $ App (NatM if_zer if_suc) x
 
 -- match x { 1n+p: s ; 0n: z }
 -- ---------------------------
 -- ~x { 0n: z ; 1n+: λp. s }
-match d span x ms (([(cut -> Suc p)], s) : ([(cut -> Zer)], z) : _) =
-  apps d (map snd ms) $ App (NatM if_zer if_suc) x
-  where if_zer = lam d (map fst ms) $ desugarPats d span z
-        if_suc = Lam (patOf d p) (Just Nat) $ \x -> lam d (map fst ms) $ desugarPats (d+1) span s
+match d span x ms (([(cut -> Suc p)], s) : ([(cut -> Zer)], z) : _) = do
+  z' <- desugarPats d span z
+  s' <- desugarPats (d+1) span s
+  let if_zer = lam d (map fst ms) z'
+  let if_suc = Lam (patOf d p) (Just Nat) $ \x -> lam d (map fst ms) s'
+  Done $ apps d (map snd ms) $ App (NatM if_zer if_suc) x
 
 -- match x { 0n: z ; k: v }
 -- --------------------------------------
 -- ~x { 0n: z ; 1n+: λk. v[k := 1n+k] }
-match d span x ms (([(cut -> Zer)], z) : ([(cut -> Var k i)], v) : _) =
-  apps d (map snd ms) $ App (NatM if_zer if_suc) x
-  where if_zer = lam d (map fst ms) $ desugarPats d span z
-        if_suc = Lam k (Just Nat) $ \x -> lam d (map fst ms) $ desugarPats (d+1) span (bindVarByName k (Suc (Var k 0)) v)
+match d span x ms (([(cut -> Zer)], z) : ([(cut -> Var k i)], v) : _) = do
+  z' <- desugarPats d span z
+  v' <- desugarPats (d+1) span (bindVarByName k (Suc (Var k 0)) v)
+  let if_zer = lam d (map fst ms) z'
+  let if_suc = Lam k (Just Nat) $ \x -> lam d (map fst ms) v'
+  Done $ apps d (map snd ms) $ App (NatM if_zer if_suc) x
 
 -- match x { 1n+p: s ; k: v }
 -- ------------------------------------
 -- ~x { 0n: v[k := 0n] ; 1n+: λp. s }
-match d span x ms (([(cut -> Suc p)], s) : ([(cut -> Var k i)], v) : _) =
-  apps d (map snd ms) $ App (NatM if_zer if_suc) x
-  where if_zer = lam d (map fst ms) $ desugarPats d span (bindVarByName k Zer v)
-        if_suc = Lam (patOf d p) (Just Nat) $ \x -> lam d (map fst ms) $ desugarPats (d+1) span s
+match d span x ms (([(cut -> Suc p)], s) : ([(cut -> Var k i)], v) : _) = do
+  v' <- desugarPats d span (bindVarByName k Zer v)
+  s' <- desugarPats (d+1) span s
+  let if_zer = lam d (map fst ms) v'
+  let if_suc = Lam (patOf d p) (Just Nat) $ \x -> lam d (map fst ms) s'
+  Done $ apps d (map snd ms) $ App (NatM if_zer if_suc) x
 
 -- match x { False: f ; True: t }
 -- ------------------------------
 -- ~x { False: f ; True: t }
-match d span x ms (([(cut -> Bt0)], f) : ([(cut -> Bt1)], t) : _) =
-  apps d (map snd ms) $ App (BitM (lam d (map fst ms) $ desugarPats d span f) (lam d (map fst ms) $ desugarPats d span t)) x
+match d span x ms (([(cut -> Bt0)], f) : ([(cut -> Bt1)], t) : _) = do
+  f' <- desugarPats d span f
+  t' <- desugarPats d span t
+  Done $ apps d (map snd ms) $ App (BitM (lam d (map fst ms) f') (lam d (map fst ms) t')) x
 
 -- match x { True: t ; False: f }
 -- ------------------------------
 -- ~x { False: f ; True: t }
-match d span x ms (([(cut -> Bt1)], t) : ([(cut -> Bt0)], f) : _) =
-  apps d (map snd ms) $ App (BitM (lam d (map fst ms) $ desugarPats d span f) (lam d (map fst ms) $ desugarPats d span t)) x
+match d span x ms (([(cut -> Bt1)], t) : ([(cut -> Bt0)], f) : _) = do
+  f' <- desugarPats d span f
+  t' <- desugarPats d span t
+  Done $ apps d (map snd ms) $ App (BitM (lam d (map fst ms) f') (lam d (map fst ms) t')) x
 
 -- match x { False: f ; k: v }
 -- --------------------------------------
 -- ~x { False: f ; True: v[k := True] }
-match d span x ms (([(cut -> Bt0)], f) : ([(cut -> Var k i)], v) : _) =
-  apps d (map snd ms) $ App (BitM (lam d (map fst ms) $ desugarPats d span f) (lam d (map fst ms) $ desugarPats d span (bindVarByName k Bt1 v))) x
+match d span x ms (([(cut -> Bt0)], f) : ([(cut -> Var k i)], v) : _) = do
+  f' <- desugarPats d span f
+  v' <- desugarPats d span (bindVarByName k Bt1 v)
+  Done $ apps d (map snd ms) $ App (BitM (lam d (map fst ms) f') (lam d (map fst ms) v')) x
 
 -- match x { True: t ; k: v }
 -- ---------------------------------------
 -- ~x { False: v[k := False] ; True: t }
-match d span x ms (([(cut -> Bt1)], t) : ([(cut -> Var k i)], v) : _) =
-  apps d (map snd ms) $ App (BitM (lam d (map fst ms) $ desugarPats d span (bindVarByName k Bt0 v)) (lam d (map fst ms) $ desugarPats d span t)) x
+match d span x ms (([(cut -> Bt1)], t) : ([(cut -> Var k i)], v) : _) = do
+  v' <- desugarPats d span (bindVarByName k Bt0 v)
+  t' <- desugarPats d span t
+  Done $ apps d (map snd ms) $ App (BitM (lam d (map fst ms) v') (lam d (map fst ms) t')) x
 
 -- match x { []: n ; h<>t: c }
 -- ------------------------------
 -- ~x { []: n ; <>: λh. λt. c }
-match d span x ms (([(cut -> Nil)], n) : ([(cut -> Con h t)], c) : _) =
-  apps d (map snd ms) $ App (LstM if_nil if_con) x
-  where if_nil = lam d (map fst ms) $ desugarPats d span n
-        if_con = Lam (patOf d h) Nothing $ \_ -> Lam (patOf (d+1) t) Nothing $ \_ -> lam d (map fst ms) $ desugarPats (d+2) span c
+match d span x ms (([(cut -> Nil)], n) : ([(cut -> Con h t)], c) : _) = do
+  n' <- desugarPats d span n
+  c' <- desugarPats (d+2) span c
+  let if_nil = lam d (map fst ms) n'
+  let if_con = Lam (patOf d h) Nothing $ \_ -> Lam (patOf (d+1) t) Nothing $ \_ -> lam d (map fst ms) c'
+  Done $ apps d (map snd ms) $ App (LstM if_nil if_con) x
 
 -- match x { h<>t: c ; []: n }
 -- ------------------------------
 -- ~x { []: n ; <>: λh. λt. c }
-match d span x ms (([(cut -> Con h t)], c) : ([(cut -> Nil)], n) : _) =
-  apps d (map snd ms) $ App (LstM if_nil if_con) x
-  where if_nil = lam d (map fst ms) $ desugarPats d span n
-        if_con = Lam (patOf d h) Nothing $ \_ -> Lam (patOf (d+1) t) Nothing $ \_ -> lam d (map fst ms) $ desugarPats (d+2) span c
+match d span x ms (([(cut -> Con h t)], c) : ([(cut -> Nil)], n) : _) = do
+  n' <- desugarPats d span n
+  c' <- desugarPats (d+2) span c
+  let if_nil = lam d (map fst ms) n'
+  let if_con = Lam (patOf d h) Nothing $ \_ -> Lam (patOf (d+1) t) Nothing $ \_ -> lam d (map fst ms) c'
+  Done $ apps d (map snd ms) $ App (LstM if_nil if_con) x
 
 -- match x { []: n ; k: v }
 -- -----------------------------------------
 -- ~x { []: n ; <>: λh. λt. v[k := h<>t] }
-match d span x ms (([(cut -> Nil)], n) : ([(cut -> Var k i)], v) : _) =
-  apps d (map snd ms) $ App (LstM if_nil if_con) x
-  where if_nil = lam d (map fst ms) $ desugarPats d span n
-        if_con = Lam (nam d) Nothing $ \_ -> Lam (nam (d+1)) Nothing $ \_ -> lam d (map fst ms) $ desugarPats (d+2) span (bindVarByName k (Con (var d) (var (d+1))) v)
+match d span x ms (([(cut -> Nil)], n) : ([(cut -> Var k i)], v) : _) = do
+  n' <- desugarPats d span n
+  v' <- desugarPats (d+2) span (bindVarByName k (Con (var d) (var (d+1))) v)
+  let if_nil = lam d (map fst ms) n'
+  let if_con = Lam (nam d) Nothing $ \_ -> Lam (nam (d+1)) Nothing $ \_ -> lam d (map fst ms) v'
+  Done $ apps d (map snd ms) $ App (LstM if_nil if_con) x
 
 -- match x { h<>t: c ; k: v }
 -- ---------------------------------------
 -- ~x { []: v[k := []] ; <>: λh. λt. c }
-match d span x ms (([(cut -> Con h t)], c) : ([(cut -> Var k i)], v) : _) =
-  apps d (map snd ms) $ App (LstM if_nil if_con) x
-  where if_nil = lam d (map fst ms) $ desugarPats d span (bindVarByName k Nil v)
-        if_con = Lam (patOf d h) Nothing $ \_ -> Lam (patOf (d+1) t) Nothing $ \_ -> lam d (map fst ms) $ desugarPats (d+2) span c
+match d span x ms (([(cut -> Con h t)], c) : ([(cut -> Var k i)], v) : _) = do
+  v' <- desugarPats d span (bindVarByName k Nil v)
+  c' <- desugarPats (d+2) span c
+  let if_nil = lam d (map fst ms) v'
+  let if_con = Lam (patOf d h) Nothing $ \_ -> Lam (patOf (d+1) t) Nothing $ \_ -> lam d (map fst ms) c'
+  Done $ apps d (map snd ms) $ App (LstM if_nil if_con) x
 
 -- match x { (): u }
 -- -----------------
 -- ~x { (): u }
 -- Preserve location from the unit pattern: if the case pattern is a located
 -- '()', then the generated λ{(): ...} inherits that original location.
-match d span x ms (([p], u) : _) | isUnitPat p =
-  let mloc = unitPatLoc p in
-  let body = lam d (map fst ms) $ desugarPats d span u in
-  let uni  = maybe (UniM body) (\sp -> Loc sp (UniM body)) mloc in
-  apps d (map snd ms) $ App uni x
+match d span x ms (([p], u) : _) | isUnitPat p = do
+  u' <- desugarPats d span u
+  let mloc = unitPatLoc p
+  let body = lam d (map fst ms) u'
+  let uni  = maybe (UniM body) (\sp -> Loc sp (UniM body)) mloc
+  Done $ apps d (map snd ms) $ App uni x
   where
     isUnitPat :: Term -> Bool
     isUnitPat (cut -> One) = True
@@ -181,12 +288,13 @@ match d span x ms (([p], u) : _) | isUnitPat p =
 -- --------------------
 -- ~x { (,): λa. λb. p }
 -- Preserve location for tuple patterns
-match d span x ms (([tup], p) : _) | isTupPat tup =
-  let mloc = tupPatLoc tup in
-  let (a, b) = tupPatFields tup in
-  let if_tup = Lam (patOf d a) Nothing $ \_ -> Lam (patOf (d+1) b) Nothing $ \_ -> lam d (map fst ms) $ desugarPats (d+2) span p in
-  let sigm = maybe (SigM if_tup) (\sp -> Loc sp (SigM if_tup)) mloc in
-  apps d (map snd ms) $ App sigm x
+match d span x ms (([tup], p) : _) | isTupPat tup = do
+  p' <- desugarPats (d+2) span p
+  let mloc = tupPatLoc tup
+  let (a, b) = tupPatFields tup
+  let if_tup = Lam (patOf d a) Nothing $ \_ -> Lam (patOf (d+1) b) Nothing $ \_ -> lam d (map fst ms) p'
+  let sigm = maybe (SigM if_tup) (\sp -> Loc sp (SigM if_tup)) mloc
+  Done $ apps d (map snd ms) $ App sigm x
   where
     isTupPat :: Term -> Bool
     isTupPat (cut -> Tup _ _) = True
@@ -197,45 +305,50 @@ match d span x ms (([tup], p) : _) | isTupPat tup =
     tupPatFields :: Term -> (Term, Term)
     tupPatFields (cut -> Tup a b) = (a, b)
     tupPatFields (Loc _ (cut -> Tup a b)) = (a, b)
-    tupPatFields _ = error "tupPatFields: not a tuple"
+    tupPatFields _ = (Era, Era) -- Should never reach here due to guard
 
 -- match x { @S1: b1 ; @S2: b2 ; ... ; k: d }
 -- ------------------------------------------
 -- ~x { @S1:b1 ; @S2:b2 ; ... ; d }
-match d span x ms cs@(([(cut -> Sym _)], _) : _) =
-  let (cBranches, defBranch) = collect cs
-      enumMatch = case span of
+match d span x ms cs@(([(cut -> Sym _)], _) : _) = do
+  (cBranches, defBranch) <- collect cs
+  let enumMatch = case span of
         Span (0,0) (0,0) _ _ -> EnuM cBranches defBranch  -- noSpan case
         _                    -> Loc span (EnuM cBranches defBranch)
-  in apps d (map snd ms) $ App enumMatch x
+  Done $ apps d (map snd ms) $ App enumMatch x
   where
-    collect :: [Case] -> ([(String, Term)], Term)
-    collect [] = ([], Lam "_" Nothing $ \_ -> lam d (map fst ms) $ One)
-    collect (([(cut -> Sym s)], rhs) : rest) =
-      let (cs, def) = collect rest
-      in ((s, lam d (map fst ms) $ desugarPats d span rhs) : cs, def)
-    collect (([(cut -> Var k _)], rhs) : _) =
-      ([], Lam k Nothing $ \_ -> lam d (map fst ms) $ desugarPats (d+1) span rhs)
-    collect (c:_) = errorWithSpan span "Invalid pattern: invalid Sym case"
+    collect :: [Case] -> Result ([(String, Term)], Term)
+    collect [] = Done ([], Lam "_" Nothing $ \_ -> lam d (map fst ms) $ One)
+    collect (([(cut -> Sym s)], rhs) : rest) = do
+      rhs' <- desugarPats d span rhs
+      (cs, def) <- collect rest
+      Done ((s, lam d (map fst ms) rhs') : cs, def)
+    collect (([(cut -> Var k _)], rhs) : _) = do
+      rhs' <- desugarPats (d+1) span rhs
+      Done ([], Lam k Nothing $ \_ -> lam d (map fst ms) rhs')
+    collect (c:_) = Fail $ Unsupported span (Ctx []) (Just "Invalid pattern: invalid Sym case")
 
 -- match x { &L{a,b}: s }
 -- ---------------------------
 -- ~ x { &L{,}: λa. λb. s }
-match d span x ms (([(cut -> Sup l a b)], s) : _) =
-  apps d (map snd ms) $ App (SupM l if_sup) x
-  where if_sup = Lam (patOf d a) Nothing $ \_ -> Lam (patOf (d+1) b) Nothing $ \_ -> lam d (map fst ms) $ desugarPats (d+2) span s
+match d span x ms (([(cut -> Sup l a b)], s) : _) = do
+  s' <- desugarPats (d+2) span s
+  let if_sup = Lam (patOf d a) Nothing $ \_ -> Lam (patOf (d+1) b) Nothing $ \_ -> lam d (map fst ms) s'
+  Done $ apps d (map snd ms) $ App (SupM l if_sup) x
 
 -- match x { Rfl: r }
 -- ------------------
 -- ~x { Rfl: r }
-match d span x ms (([(cut -> Rfl)], r) : _) =
-  apps d (map snd ms) $ App (EqlM (lam d (map fst ms) $ desugarPats d span r)) x
+match d span x ms (([(cut -> Rfl)], r) : _) = do
+  r' <- desugarPats d span r
+  Done $ apps d (map snd ms) $ App (EqlM (lam d (map fst ms) r')) x
 
 -- match x { k: body }
 -- -------------------
 -- body[k := x]
-match d span x ms (([(cut -> Var k i)], body) : _) =
-  lam d (map fst ms) $ desugarPats d span (shove d ((k, x) : ms) body)
+match d span x ms (([(cut -> Var k i)], body) : _) = do
+  body' <- desugarPats d span (shove d ((k, x) : ms) body)
+  Done $ lam d (map fst ms) body'
 
 -- match x { }
 -- -----------
@@ -244,11 +357,11 @@ match d span x ms [] =
   let empMatch = case span of
         Span (0,0) (0,0) _ _ -> EmpM  -- Keep noSpan as raw EmpM
         _                    -> Loc span EmpM  -- Preserve location for error reporting
-  in apps d (map snd ms) (App empMatch x)
+  in Done $ apps d (map snd ms) (App empMatch x)
 
 -- Invalid pattern
 -- match d span s ms cs = error $ "match - invalid pattern: " ++ show (d, s, ms, cs) ++ "\n" ++ show span
-match d span s ms cs = errorWithSpan span "Invalid pattern."
+match d span s ms cs = Fail $ Unsupported span (Ctx []) (Just "Invalid pattern")
 
 -- Helper function to create lambda abstractions
 lam :: Int -> [Name] -> Term -> Term

--- a/src/Core/Adjust/ResolveEnums.hs
+++ b/src/Core/Adjust/ResolveEnums.hs
@@ -19,6 +19,7 @@ import Data.List (intercalate, isPrefixOf)
 import Data.List.Split (splitOn)
 import Data.Maybe (fromMaybe)
 import Control.Monad (foldM)
+import Control.Exception (throw)
 
 import Core.Type
 import Core.Show
@@ -114,14 +115,14 @@ resolveEnumsInTerm emap = go
       Sub t -> do
         t2 <- go t
         Done (Sub t2)
-      Fix k f -> Done $ Fix k (\v -> case go (f v) of Done t -> t; Fail e -> error (show e))
+      Fix k f -> Done $ Fix k (\v -> case go (f v) of Done t -> t; Fail e -> throw (BendException e))
       Let k t v f -> do
         t2 <- mapM go t
         v2 <- go v
-        Done $ Let k t2 v2 (\u -> case go (f u) of Done t -> t; Fail e -> error (show e))
+        Done $ Let k t2 v2 (\u -> case go (f u) of Done t -> t; Fail e -> throw (BendException e))
       Use k v f -> do
         v2 <- go v
-        Done $ Use k v2 (\u -> case go (f u) of Done t -> t; Fail e -> error (show e))
+        Done $ Use k v2 (\u -> case go (f u) of Done t -> t; Fail e -> throw (BendException e))
       Chk x t -> do
         x2 <- go x
         t2 <- go t
@@ -184,7 +185,7 @@ resolveEnumsInTerm emap = go
         Done (All a2 b2)
       Lam k t f -> do
         t2 <- mapM go t
-        Done $ Lam k t2 (\u -> case go (f u) of Done t -> t; Fail e -> error (show e))
+        Done $ Lam k t2 (\u -> case go (f u) of Done t -> t; Fail e -> throw (BendException e))
       App f x -> do
         f2 <- go f
         x2 <- go x

--- a/src/Core/Check.hs
+++ b/src/Core/Check.hs
@@ -479,7 +479,7 @@ infer d span book@(Book defs names) ctx term =
 
     -- Not supported in infer
     Pat _ _ _ -> do
-      error "Pat not supported in infer"
+      Fail $ Unsupported span (normalCtx book ctx) (Just "Sugared Pat constructors not supported in type checking")
 
 -- Infer the result type of a binary numeric operation
 inferOp2Type :: Int -> Span -> Book -> Ctx -> NOp2 -> Term -> Term -> Result Term
@@ -1063,7 +1063,7 @@ check d span book ctx term      goal =
 
     -- Not supported
     (Pat _ _ _, _) -> do
-      error "not-supported"
+      Fail $ Unsupported span (normalCtx book ctx) (Just "Sugared Pat constructors not supported in type checking")
 
     -- ctx |- s : Char[]
     -- ctx |- x : T

--- a/src/Core/Equal.hs
+++ b/src/Core/Equal.hs
@@ -4,6 +4,7 @@
 
 module Core.Equal where
 
+import Control.Exception (throw)
 import System.IO.Unsafe
 import Data.IORef
 import Data.Bits
@@ -13,6 +14,7 @@ import GHC.Float (castDoubleToWord64, castWord64ToDouble)
 
 import Core.Type
 import Core.WHNF
+import Core.Show
 
 import Debug.Trace
 
@@ -99,6 +101,6 @@ cmp red d book a b =
     (Op2 oa aa ba   , Op2 ob ab bb   ) -> oa == ob && eql red d book aa ab && eql red d book ba bb
     (Op1 oa aa      , Op1 ob ab      ) -> oa == ob && eql red d book aa ab
     (Pri pa         , Pri pb         ) -> pa == pb
-    (Met _  _  _    , Met _  _  _    ) -> error "not-supported"
-    (Pat _  _  _    , Pat _  _  _    ) -> error "not-supported"
+    (Met _  _  _    , Met _  _  _    ) -> throw (BendException $ Unsupported noSpan (Ctx []) (Just "Meta variables not supported in equality checking"))
+    (Pat _  _  _    , Pat _  _  _    ) -> throw (BendException $ Unsupported noSpan (Ctx []) (Just "Sugared Pat constructors not supported in equality checking"))
     (_              , _              ) -> False

--- a/src/Core/Parse/Term.hs
+++ b/src/Core/Parse/Term.hs
@@ -1166,7 +1166,9 @@ doParseTerm :: FilePath -> String -> Either String Term
 doParseTerm file input =
   case evalState (runParserT p file input) (ParserState True input [] M.empty [] 0 file) of
     Left err  -> Left (formatError input err)
-    Right res -> Right (adjust (Book M.empty []) res)
+    Right res -> case adjust (Book M.empty []) res of
+      Done t -> Right t
+      Fail e -> Left (show e)
   where
     p = do
       skip

--- a/src/Core/Show.hs
+++ b/src/Core/Show.hs
@@ -550,7 +550,9 @@ instance Show Book where
     where showDefn k (_, x, t) = k ++ " : " ++ show t ++ " = " ++ showTerm False True x
 
 instance Show Span where
-  show span = "\n\x1b[1mLocation:\x1b[0m \x1b[2m(line " ++ show (fst $ spanBeg span) ++ ", column " ++ show (snd $ spanBeg span) ++ ")\x1b[0m\n" ++ highlightError (spanBeg span) (spanEnd span) (spanSrc span)
+  show span
+    | spanBeg span == (0,0) && spanEnd span == (0,0) && spanSrc span == "" = ""
+    | otherwise = "\n\x1b[1mLocation:\x1b[0m \x1b[2m(line " ++ show (fst $ spanBeg span) ++ ", column " ++ show (snd $ spanBeg span) ++ ")\x1b[0m\n" ++ highlightError (spanBeg span) (spanEnd span) (spanSrc span)
 
 showHint :: Maybe String -> String
 showHint Nothing = ""
@@ -567,6 +569,7 @@ instance Show Error where
     UnknownTermination term  -> "\x1b[1mUnknownTermination:\x1b[0m " ++ show term
     ImportError span msg     -> "\x1b[1mImportError:\x1b[0m " ++ msg ++ show span
     AmbiguousEnum span ctx ctor fqns hint -> "\x1b[1mAmbiguousEnum:\x1b[0m &" ++ ctor ++ "\nCould be:\n" ++ unlines ["  - &" ++ fqn | fqn <- fqns] ++ showHint hint ++ "\x1b[1mContext:\x1b[0m\n" ++ show ctx ++ show span
+    CompilationError msg -> "\x1b[1mCompilationError:\x1b[0m " ++ msg
 
 -- Exception wrapper for Error
 newtype BendException = BendException Error

--- a/src/Core/Show.hs
+++ b/src/Core/Show.hs
@@ -5,9 +5,11 @@
 module Core.Show where
 
 import Core.Type
+import Control.Exception (Exception)
 import Data.List (intercalate, unsnoc, isInfixOf, isPrefixOf)
 import Data.List.Split (splitOn)
 import Data.Maybe (fromMaybe)
+import Data.Typeable (Typeable)
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Highlight (highlightError)
@@ -565,6 +567,15 @@ instance Show Error where
     UnknownTermination term  -> "\x1b[1mUnknownTermination:\x1b[0m " ++ show term
     ImportError span msg     -> "\x1b[1mImportError:\x1b[0m " ++ msg ++ show span
     AmbiguousEnum span ctx ctor fqns hint -> "\x1b[1mAmbiguousEnum:\x1b[0m &" ++ ctor ++ "\nCould be:\n" ++ unlines ["  - &" ++ fqn | fqn <- fqns] ++ showHint hint ++ "\x1b[1mContext:\x1b[0m\n" ++ show ctx ++ show span
+
+-- Exception wrapper for Error
+newtype BendException = BendException Error
+  deriving (Typeable)
+
+instance Show BendException where
+  show (BendException e) = show e
+
+instance Exception BendException
 
 instance Show Ctx where
   show (Ctx ctx) = case lines of

--- a/src/Core/Type.hs
+++ b/src/Core/Type.hs
@@ -189,6 +189,7 @@ data Error
   | UnknownTermination Term
   | ImportError Span String
   | AmbiguousEnum Span Ctx String [String] (Maybe String)
+  | CompilationError String
 
 
 data Result a

--- a/src/Core/Type.hs
+++ b/src/Core/Type.hs
@@ -190,6 +190,7 @@ data Error
   | ImportError Span String
   | AmbiguousEnum Span Ctx String [String] (Maybe String)
 
+
 data Result a
   = Done a
   | Fail Error

--- a/src/Target/Haskell.hs
+++ b/src/Target/Haskell.hs
@@ -4,6 +4,8 @@
 
 module Target.Haskell where
 
+import Control.Exception (throw)
+import qualified Core.Show as Show
 import Core.Type
 import Core.WHNF
 import Data.Char (isUpper)
@@ -145,15 +147,15 @@ termToHT book i term = case term of
   Rfl         -> HOne
   EqlM f      -> HLam "_" (termToHT book i f)
   Rwt _ f     -> termToHT book i f
-  Met _ _ _   -> error "Metas not supported for Haskell compilation"
+  Met _ _ _   -> throw (Show.BendException $ CompilationError "Meta variables not supported for Haskell compilation")
   Era         -> HEra
-  Sup _ _ _   -> error "Superpositions not supported for Haskell compilation"
-  SupM _ _    -> error "Superposition matches not supported for Haskell compilation"
+  Sup _ _ _   -> throw (Show.BendException $ CompilationError "Superpositions not supported for Haskell compilation")
+  SupM _ _    -> throw (Show.BendException $ CompilationError "Superposition matches not supported for Haskell compilation")
   Log s x     -> HLog (termToHT book i s) (termToHT book i x)
   Loc _ t     -> termToHT book i t
   Pri p       -> HPri p
   Pat xs _ cs -> HMat (map (termToHT book i) xs) (map (\(ps, b) -> (map (termToHT book i) ps, termToHT book i b)) cs)
-  Frk _ _ _   -> error "Fork not supported for Haskell compilation"
+  Frk _ _ _   -> throw (Show.BendException $ CompilationError "Fork constructs not supported for Haskell compilation")
 
 -- Convert a Bend term to a Haskell type.
 typeToHT :: Book -> Type -> HT
@@ -262,7 +264,7 @@ showPat pat = case pat of
   HBt1     -> "True"
   HBt0     -> "False"
   HSym s   -> "\"" ++ s ++ "\""
-  _ -> error "Invalid pattern"
+  _ -> throw (Show.BendException $ CompilationError "Invalid pattern in Haskell compilation")
 
 -- Convert binary operators to Haskell
 showOp2 :: NOp2 -> String


### PR DESCRIPTION
This PR aims to replace ugly runtime crashes with the good looking errors we already had the the `Check` step.

However, since we work with a HOAS representation in some pipelines, I used `Exceptions` and `throw` wrapping  `Error` with `BendExcepction` to keep the same format.

Fixed it throughout the entire codebase to keep the pattern